### PR TITLE
refactor : 주문 구매 내역 조회시, 옵션이 String의 쌍으로 나오도록 구현 #170

### DIFF
--- a/src/main/java/spharos/msg/domain/options/controller/OptionsController.java
+++ b/src/main/java/spharos/msg/domain/options/controller/OptionsController.java
@@ -3,7 +3,10 @@ package spharos.msg.domain.options.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import spharos.msg.domain.options.service.OptionsService;
 import spharos.msg.global.api.ApiResponse;
 
@@ -12,37 +15,30 @@ import spharos.msg.global.api.ApiResponse;
 @Tag(name = "Options", description = "옵션 관련 API")
 @RequestMapping("/api/v1/option")
 public class OptionsController {
+
     private final OptionsService optionsService;
+
     @Operation(summary = "상품 옵션 종류 조회",
-            description = "상품 ID를 입력하면 해당 상품의 옵션 종류를 조회 합니다. (색상,사이즈,기타)")
+        description = "상품 ID를 입력하면 해당 상품의 옵션 종류를 조회 합니다. (색상,사이즈,기타)")
     @GetMapping("/type/{productId}")
     public ApiResponse<?> getOptionsType(
-            @PathVariable Long productId)
-    {
+        @PathVariable Long productId) {
         return optionsService.getOptionsType(productId);
     }
+
     @Operation(summary = "최상위 옵션 조회",
-            description = "상품 ID를 입력하면 해당 상품의 최상위 옵션을 조회 합니다.")
+        description = "상품 ID를 입력하면 해당 상품의 최상위 옵션을 조회 합니다.")
     @GetMapping("/first/{productId}")
     public ApiResponse<?> getFirstOptions(
-            @PathVariable Long productId)
-    {
+        @PathVariable Long productId) {
         return optionsService.getFirstOptions(productId);
     }
+
     @Operation(summary = "자식 옵션 조회",
-            description = "최상위 옵션에 있는 옵션 ID를 선택 시 해당 옵션의 자식 옵션을 조회 합니다.")
+        description = "최상위 옵션에 있는 옵션 ID를 선택 시 해당 옵션의 자식 옵션을 조회 합니다.")
     @GetMapping("/child/{optionsId}")
     public ApiResponse<?> getChildOptions(
-            @PathVariable Long optionsId)
-    {
+        @PathVariable Long optionsId) {
         return optionsService.getChildOptions(optionsId);
-    }
-    @Operation(summary = "옵션 조회",
-            description = "상품의 옵션을 조회합니다. (빨강,L)")
-    @GetMapping
-    public ApiResponse<?> getOptions(
-            @RequestParam(value = "productOptionId") Long productOptionId)
-    {
-        return optionsService.getOptions(productOptionId);
     }
 }

--- a/src/main/java/spharos/msg/domain/options/service/OptionsService.java
+++ b/src/main/java/spharos/msg/domain/options/service/OptionsService.java
@@ -1,10 +1,13 @@
 package spharos.msg.domain.options.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spharos.msg.domain.options.dto.OptionTypeDto;
-import spharos.msg.domain.options.dto.OptionsNameDto;
 import spharos.msg.domain.options.dto.OptionsResponseDto;
 import spharos.msg.domain.options.entity.Options;
 import spharos.msg.domain.options.repository.OptionsRepository;
@@ -18,15 +21,12 @@ import spharos.msg.global.api.code.status.SuccessStatus;
 import spharos.msg.global.api.exception.OptionsException;
 import spharos.msg.global.api.exception.ProductNotExistException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OptionsService {
+
+    private static final String OPTION_DELIMETER = "/";
     private final OptionsRepository optionsRepository;
     private final ProductOptionRepository productOptionRepository;
     private final ProductRepository productRepository;
@@ -34,7 +34,7 @@ public class OptionsService {
     //상품 옵션 종류 조회
     public ApiResponse<?> getOptionsType(Long productId) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ProductNotExistException(ErrorStatus.NOT_EXIST_PRODUCT_ID));
+            .orElseThrow(() -> new ProductNotExistException(ErrorStatus.NOT_EXIST_PRODUCT_ID));
 
         List<ProductOption> productOptions = productOptionRepository.findByProduct(product);
         List<OptionTypeDto> optionTypeDtos = new ArrayList<>();
@@ -50,18 +50,19 @@ public class OptionsService {
 
         return ApiResponse.of(SuccessStatus.OPTION_TYPE_SUCCESS, optionTypeDtos);
     }
+
     //최상위 옵션 조회
     public ApiResponse<?> getFirstOptions(Long productId) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ProductNotExistException(ErrorStatus.NOT_EXIST_PRODUCT_ID));
+            .orElseThrow(() -> new ProductNotExistException(ErrorStatus.NOT_EXIST_PRODUCT_ID));
 
         List<ProductOption> productOptions = productOptionRepository.findByProduct(product);
 
-        if(productOptions.get(0).getOptions().getParent() == null){
+        if (productOptions.get(0).getOptions().getParent() == null) {
             return ApiResponse.of(SuccessStatus.OPTION_FIRST_SUCCESS,
-                    productOptions.stream()
-                            .map(OptionsResponseDto::new)
-                            .toList());
+                productOptions.stream()
+                    .map(OptionsResponseDto::new)
+                    .toList());
         }
         Set<Long> parentIds = getParentOptionIds(productOptions);
         List<OptionsResponseDto> optionDetailList = getParentOptionDetails(parentIds);
@@ -70,35 +71,41 @@ public class OptionsService {
         if (parentOptionDetailList.isEmpty()) {
             return ApiResponse.of(SuccessStatus.OPTION_FIRST_SUCCESS, optionDetailList);
         }
-        return ApiResponse.of(SuccessStatus.OPTION_ID_SUCCESS, parentOptionDetailList.stream().distinct());
+        return ApiResponse.of(SuccessStatus.OPTION_ID_SUCCESS,
+            parentOptionDetailList.stream().distinct());
     }
-    //상품 옵션 조회
-    public ApiResponse<?> getOptions(Long productOptionId) {
-        ProductOption productOption = productOptionRepository.findById(productOptionId).orElseThrow();
-        Options options = productOption.getOptions();
-        List<OptionsNameDto> optionsNameDtos = new ArrayList<>();
 
-        optionsNameDtos.add(new OptionsNameDto(options));
+    //상품 옵션 조회
+    public String getOptions(Long productOptionId) {
+        ProductOption productOption = productOptionRepository.findById(productOptionId)
+            .orElseThrow();
+        Options options = productOption.getOptions();
+        List<String> optionNames = new ArrayList<>();
+
+        optionNames.add(options.getOptionName());
 
         while (options.getParent() != null) {
-            optionsNameDtos.add(new OptionsNameDto(options.getParent()));
+            optionNames.add(options.getParent().getOptionName());
             options = options.getParent();
         }
-        return ApiResponse.of(SuccessStatus.OPTION_DETAIL_SUCCESS, optionsNameDtos);
+        return String.join(OPTION_DELIMETER, optionNames);
     }
-    private void addOptionTypeDtoFromParentIds(Set<Long> parentIds, List<OptionTypeDto> optionTypeDtos) {
+
+    private void addOptionTypeDtoFromParentIds(Set<Long> parentIds,
+        List<OptionTypeDto> optionTypeDtos) {
         Options options = getOptionsById(parentIds.iterator().next());
         optionTypeDtos.add(new OptionTypeDto(options));
     }
 
     private Options getOptionsById(Long optionsId) {
         return optionsRepository.findById(optionsId)
-                .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION));
+            .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION));
     }
+
     //하위 옵션 데이터 조회
     public ApiResponse<?> getChildOptions(Long optionsId) {
         Options options = optionsRepository.findById(optionsId)
-                .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION));
+            .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION));
 
         List<Options> childOptions = options.getChild();
         //하위 옵션이 없다면 던지고 있다면 해당 옵션 리스트 반환
@@ -106,35 +113,36 @@ public class OptionsService {
             throw new OptionsException(ErrorStatus.NOT_EXIST_CHILD_OPTION);
         }
         return ApiResponse.of(SuccessStatus.OPTION_DETAIL_SUCCESS,
-                childOptions.stream()
-                        .map(option -> new OptionsResponseDto(option, productOptionRepository.findByOptions(option).getStock()))
-                        .toList());
+            childOptions.stream()
+                .map(option -> new OptionsResponseDto(option,
+                    productOptionRepository.findByOptions(option).getStock()))
+                .toList());
     }
 
     //상품이 가진 최하위 옵션 ID의 상위 옵션 ID 취합
     private Set<Long> getParentOptionIds(List<ProductOption> productOptions) {
         return productOptions.stream()
-                .map(productOption -> productOption.getOptions().getParent().getId())
-                .collect(Collectors.toSet());
+            .map(productOption -> productOption.getOptions().getParent().getId())
+            .collect(Collectors.toSet());
     }
 
     //해당 ID들의 정보(옵션ID,이름,타입,레벨) 반환
     private List<OptionsResponseDto> getParentOptionDetails(Set<Long> parentIds) {
         return parentIds.stream()
-                .map(optionId -> optionsRepository.findById(optionId)
-                        .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION)))
-                .map(option -> new OptionsResponseDto(option, null))
-                .toList();
+            .map(optionId -> optionsRepository.findById(optionId)
+                .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION)))
+            .map(option -> new OptionsResponseDto(option, null))
+            .toList();
     }
 
     //한단계 더 상위 옵션이 있는지 검증 및 있다면 해당 옵션 정보 반환
     private List<OptionsResponseDto> getFinalParentOptionDetails(Set<Long> parentIds) {
         return parentIds.stream()
-                .map(optionId -> optionsRepository.findById(optionId)
-                        .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION)))
-                .filter(options -> options.getParent() != null)
-                .map(options -> new OptionsResponseDto(options.getParent(), null))
-                .toList();
+            .map(optionId -> optionsRepository.findById(optionId)
+                .orElseThrow(() -> new OptionsException(ErrorStatus.NOT_EXIST_PRODUCT_OPTION)))
+            .filter(options -> options.getParent() != null)
+            .map(options -> new OptionsResponseDto(options.getParent(), null))
+            .toList();
     }
 
 

--- a/src/main/java/spharos/msg/domain/orders/service/OrderProductService.java
+++ b/src/main/java/spharos/msg/domain/orders/service/OrderProductService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spharos.msg.domain.options.service.OptionsService;
 import spharos.msg.domain.orders.dto.OrderRequest.OrderProductDetail;
 import spharos.msg.domain.orders.dto.OrderRequest.OrderSheetDto;
 import spharos.msg.domain.orders.dto.OrderResponse.OrderPrice;
@@ -30,6 +31,7 @@ public class OrderProductService {
     private final OrderProductRepository orderProductRepository;
     private final ProductRepository productRepository;
     private final ProductSalesInfoRepository productSalesInfoRepository;
+    private final OptionsService optionsService;
 
     @Transactional
     public void saveAllByOrderSheet(OrderSheetDto orderSheetDto, Orders orders) {
@@ -82,10 +84,15 @@ public class OrderProductService {
             .productId(orderProductDetail.getProductId())
             .orderIsCompleted(COMPLETED_DEFAULT)
             .orders(orders)
-            .productOption("옵션1 옵션2 옵션3") // 임시값 - 변경 예정
+            .productOption(getProductOptions(orderProductDetail))
             .productName(product.getProductName())
             .productImage("TEMP VALUE") //임시값 - 변경 예정
             .build();
+    }
+
+    private String getProductOptions(OrderProductDetail detail) {
+        Long productOptionId = detail.getProductOptionId();
+        return optionsService.getOptions(productOptionId);
     }
 
     private OrderPrice toOrderPrice(OrderProduct orderProduct) {


### PR DESCRIPTION
## 개요
#170에 관한 리팩토링 내용입니다.
리팩토링 도중 옵션 조회에 관한 API를 없애고, 이를 서비스 단에서 코드를 많이 바꿨습니다.


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
